### PR TITLE
feat: generalize to OpenAPI MCP Server; rename package; update CLI/docs; deprecate old package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The OpenAPI→MCP tool generator is bundled in this package and exposed via a su
 Use it programmatically or via the example CLI to pre‑generate tools JSON.
 
 - Programmatic: `const { generateMcpTools } = require('@prodbybuddha/openapi-mcp-server/lib/openapi-generator');`
-- CLI: `node examples/generate-n8n-mcp-tools.js --from-url <specUrl> --out examples/generated/n8n-openapi-tools.json`
+- CLI: `node examples/generate-openapi-mcp-tools.js --from-url <specUrl> --out examples/generated/n8n-openapi-tools.json`
 
 The server can also load OpenAPI specs dynamically on startup via env vars
 (`OPENAPI_SPEC_FILE` or `OPENAPI_SPEC_URL`) without pre‑generation.
@@ -47,8 +47,8 @@ The server can also load OpenAPI specs dynamically on startup via env vars
 
 The server can load OpenAPI tools at startup via the bundled generator. Set one of:
 
-- `OPENAPI_SPEC_FILE=./path/to/openapi.json npm run mcp:n8n`
-- `OPENAPI_SPEC_URL=https://api.example.com/openapi.json npm run mcp:n8n`
+- `OPENAPI_SPEC_FILE=./path/to/openapi.json npm run mcp:openapi`
+- `OPENAPI_SPEC_URL=https://api.example.com/openapi.json npm run mcp:openapi`
 
 Optionally override the base URL used by generated tools:
 

--- a/examples/generate-openapi-mcp-tools.js
+++ b/examples/generate-openapi-mcp-tools.js
@@ -1,6 +1,6 @@
 /*
  * Generate MCP tool definitions from an OpenAPI spec using the bundled
- * universal-openapi-mcp-generator. Produces a serializable JSON file that the
+ * openapi generator. Produces a serializable JSON file that the
  * server can load offline.
  *
  * - Input: --from-url <url> or --from-file <path>
@@ -113,7 +113,7 @@ async function main() {
   } else if (args['from-url']) {
     spec = await loadSpecFromUrl(args['from-url']);
   } else {
-    console.error('Usage: node examples/generate-n8n-mcp-tools.js --from-url <url> | --from-file <path> [--out <path>]');
+    console.error('Usage: node examples/generate-openapi-mcp-tools.js --from-url <url> | --from-file <path> [--out <path>]');
     process.exit(1);
   }
 
@@ -124,3 +124,4 @@ async function main() {
 }
 
 main();
+

--- a/examples/generated/n8n-openapi-tools.json
+++ b/examples/generated/n8n-openapi-tools.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-08-19T09:54:18.582Z",
+  "generatedAt": "2025-08-19T10:11:50.894Z",
   "tools": [
     {
       "name": "deleteCredential",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mcp:n8n:once": "node examples/mcp-n8n-server.js --once",
     "mcp:openapi": "node examples/mcp-openapi-server.js",
     "mcp:openapi:once": "node examples/mcp-openapi-server.js --once",
-    "mcp:gen": "node examples/generate-n8n-mcp-tools.js",
+    "mcp:gen": "node examples/generate-openapi-mcp-tools.js",
     "mcp:tools:readme": "node examples/build-tools-readme.js",
     "mcp:list-tools": "node examples/mcp-n8n-server.js --once tools/list {}"
   },

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -71,7 +71,7 @@ async function runNode(cmd, args, env = {}) {
 async function generateTools() {
   const apiUrl = requireEnv('N8N_API_URL').replace(/\/$/, '');
   const specUrl = `${apiUrl}/docs/swagger-ui-init.js`;
-  const genScript = path.resolve(__dirname, '..', 'examples', 'generate-n8n-mcp-tools.js');
+  const genScript = path.resolve(__dirname, '..', 'examples', 'generate-openapi-mcp-tools.js');
   const outPath = path.resolve(__dirname, '..', 'examples', 'generated', 'n8n-openapi-tools.json');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   log(`Generating tools from: ${specUrl}`);

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -52,7 +52,7 @@ for (const p of envCandidates) {
 const toolsJson = path.resolve(__dirname, '..', 'examples', 'generated', 'n8n-openapi-tools.json');
 if (!fs.existsSync(toolsJson) && process.env.N8N_API_URL && process.env.N8N_API_KEY) {
   console.log('Generating tools JSON...');
-  const gen = spawnSync(process.execPath, [path.resolve(__dirname, '..', 'examples', 'generate-n8n-mcp-tools.js'), '--from-url', String(process.env.N8N_API_URL).replace(/\$/, '') + '/docs/swagger-ui-init.js', '--out', toolsJson], { stdio: 'inherit', env: process.env });
+  const gen = spawnSync(process.execPath, [path.resolve(__dirname, '..', 'examples', 'generate-openapi-mcp-tools.js'), '--from-url', String(process.env.N8N_API_URL).replace(/\$/, '') + '/docs/swagger-ui-init.js', '--out', toolsJson], { stdio: 'inherit', env: process.env });
   if (gen.status !== 0) process.exit(gen.status);
 }
 

--- a/tests/smoke.generator-load.test.js
+++ b/tests/smoke.generator-load.test.js
@@ -47,7 +47,7 @@ function readJson(filePath) {
   const specPath = path.join(tmpDir, 'simple-openapi.json');
   writeJson(specPath, spec);
   const outPath = path.join(tmpDir, 'offline-tools.json');
-  const genRes = spawnSync(process.execPath, [path.resolve(__dirname, '..', 'examples', 'generate-n8n-mcp-tools.js'), '--from-file', specPath, '--out', outPath], { stdio: 'inherit', env: process.env });
+  const genRes = spawnSync(process.execPath, [path.resolve(__dirname, '..', 'examples', 'generate-openapi-mcp-tools.js'), '--from-file', specPath, '--out', outPath], { stdio: 'inherit', env: process.env });
   assert.strictEqual(genRes.status, 0, 'generator CLI should exit 0');
   const offline = readJson(outPath);
   assert(offline && Array.isArray(offline.tools) && offline.tools.length > 0, 'offline tools JSON present');

--- a/tests/tmp/offline-tools.json
+++ b/tests/tmp/offline-tools.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-08-19T09:54:18.913Z",
+  "generatedAt": "2025-08-19T10:11:51.196Z",
   "tools": [
     {
       "name": "getWidget",


### PR DESCRIPTION
This PR:

- Generalizes the project into a generic OpenAPI → MCP server with n8n integration
- Renames package to @prodbybuddha/openapi-mcp-server (v1.2.0)
- Adds generic server entry (examples/mcp-openapi-server.js) and keeps n8n server
- Renames generator CLI to generate-openapi-mcp-tools.js; updates scripts/tests
- Exposes subpath export lib/openapi-generator
- Updates README badges, usage, and wiki references
- Deprecates @prodbybuddha/n8n-mcp-server on npm; published new package

All tests pass. Ready for review and merge.
